### PR TITLE
Re-enable license-scan and simplify pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,16 +391,16 @@ workflows:
                 - /feature*/
                 - /bugfix*/
                 - /hotfix*/
-            - license-scan:
-                context: org-global
-                requires:
-                  - build-local
-                filters:
-                  branches:
-                    ignore:
-                      - /feature*/
-                      - /bugfix*/
-                      - /hotfix*/
+      - license-scan:
+          context: org-global
+          requires:
+            - build-local
+          filters:
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
+                - /hotfix*/
       - image-scan:
           context: org-global
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,11 @@ defaults_license_scanner: &defaults_license_scanner
 # CircleCI Executors
 ##
 executors:
-  default-docker:
+  default-node:
     working_directory: /home/circleci/project
     docker:
       - image: node:12.18.0-alpine
-
-  default-machine:
+  default-ubuntu:
     machine:
       image: ubuntu-1604:201903-01
 
@@ -62,7 +61,7 @@ executors:
 ##
 jobs:
   setup:
-    executor: default-docker
+    executor: default-node
     steps:
       - checkout
       - run:
@@ -83,7 +82,7 @@ jobs:
             - node_modules
 
   test-unit:
-    executor: default-docker
+    executor: default-node
     steps:
       - checkout
       - run:
@@ -108,7 +107,7 @@ jobs:
           path: ./test/results
 
   test-integration:
-    executor: default-docker
+    executor: default-node
     steps:
       - checkout
       - run:
@@ -129,16 +128,8 @@ jobs:
       - store_test_results:
           path: ./test/results
 
-  test-build:
-    executor: default-machine
-    steps:
-      - checkout
-      - run:
-          name: Docker Build
-          command: docker build .
-
   vulnerability-check:
-    executor: default-docker
+    executor: default-node
     steps:
       - checkout
       - run:
@@ -157,7 +148,7 @@ jobs:
           prefix: audit
 
   audit-licenses:
-    executor: default-docker
+    executor: default-node
     steps:
       - checkout
       - run:
@@ -174,45 +165,46 @@ jobs:
           path: /tmp/license-scanner/results
           prefix: licenses
 
-  build:
-    executor: default-machine
+  build-local:
+    executor: default-ubuntu
     steps:
       - checkout
       - run:
-          name: Build Docker $CIRCLE_TAG image
+          name: Build Docker local image for testing
           command: >
-            echo "Building Docker image: $CIRCLE_TAG"
+            echo "Building Docker image: local"
 
             docker build
             --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
-            --build-arg=VERSION="$RELEASE_TAG"
+            --build-arg=VERSION="local"
             --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
             --build-arg=VCS_REF="$CIRCLE_SHA1"
-            -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+            -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local .
       - run:
           name: Save docker image to workspace
-          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local
       - persist_to_workspace:
           root: /tmp
           paths:
             - ./docker-image.tar
 
-#  license-scan:
-#    executor: default-machine
-#    steps:
-#      - attach_workspace:
-#          at: /tmp
-#      - run:
-#          name: Load the pre-built docker image from workspace
-#          command: docker load -i /tmp/docker-image.tar
-#      - run:
-#          <<: *defaults_license_scanner
-#      - run:
-#          name: Run the license-scanner
-#          command: cd /tmp/license-scanner && mode=docker dockerImages=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG make run
-#      - store_artifacts:
-#          path: /tmp/license-scanner/results
-#          prefix: licenses
+  license-scan:
+    executor: default-ubuntu
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Load the pre-built docker image from workspace
+          command: docker load -i /tmp/docker-image.tar
+      - run:
+          <<: *defaults_license_scanner
+      - run:
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && mode=docker dockerImages=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:local make run
+      - store_artifacts:
+          path: /tmp/license-scanner/results
+          prefix: licenses
 
   image-scan:
     executor: anchore/anchore_engine
@@ -229,7 +221,7 @@ jobs:
           command: docker load -i /tmp/docker-image.tar
       - anchore/analyze_local_image:
           dockerfile_path: ./Dockerfile
-          image_name: ${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
+          image_name: ${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:local
           # Anchore bug: if policy_failure is `true`, reports don't get written - we manually check for failures below
           policy_failure: false
           timeout: '500'
@@ -264,8 +256,31 @@ jobs:
       - store_artifacts:
           path: anchore-reports
 
+  build:
+    executor: default-ubuntu
+    steps:
+      - checkout
+      - run:
+          name: Build Docker $CIRCLE_TAG image
+          command: >
+            echo "Building Docker image: $CIRCLE_TAG"
+
+            docker build
+            --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
+            --build-arg=VERSION="$RELEASE_TAG"
+            --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
+            --build-arg=VCS_REF="$CIRCLE_SHA1"
+            -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+      - run:
+          name: Save docker image to workspace
+          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ./docker-image.tar
+
   publish:
-    executor: default-machine
+    executor: default-ubuntu
     steps:
       - checkout
       - attach_workspace:
@@ -323,89 +338,82 @@ workflows:
               ignore:
                 - /feature*/
                 - /bugfix*/
+                - /hotfix*/
       - test-unit:
           context: org-global
           requires:
             - setup
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore:
                 - /feature*/
                 - /bugfix*/
+                - /hotfix*/
       - test-integration:
           context: org-global
           requires:
             - setup
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore:
                 - /feature*/
                 - /bugfix*/
-      - test-build:
-          context: org-global
-          requires:
-            - setup
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore:
-                - /feature*/
-                - /bugfix*/
+                - /hotfix*/
       - vulnerability-check:
           context: org-global
           requires:
             - setup
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore:
                 - /feature*/
                 - /bugfix*/
+                - /hotfix*/
       - audit-licenses:
           context: org-global
           requires:
             - setup
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore:
                 - /feature*/
                 - /bugfix*/
-      - build:
+                - /hotfix*/
+      - build-local:
           context: org-global
           requires:
-            - setup
             - test-unit
-            - test-build
             - vulnerability-check
             - audit-licenses
           filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(\-snapshot)?(\-hotfix(\.[0-9]+))?/
             branches:
               ignore:
-                - /.*/
-#      - license-scan:
-#          context: org-global
-#          requires:
-#            - build
-#          filters:
-#            tags:
-#              only: /v[0-9]+(\.[0-9]+)*(\-snapshot)?(\-hotfix(\.[0-9]+))?/
-#            branches:
-#              ignore:
-#                - /.*/
+                - /feature*/
+                - /bugfix*/
+                - /hotfix*/
+      #      TODO: This job needs to have its issues diagnosed and fixed - currently does work against prebuilt images correctly
+      #      - license-scan:
+      #          context: org-global
+      #          requires:
+      #            - build-local
+      #          filters:
+      #            branches:
+      #              ignore:
+      #                - /feature*/
+      #                - /bugfix*/
+      #                - /hotfix*/
       - image-scan:
           context: org-global
           requires:
-            - build
+            - build-local
+          filters:
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
+                - /hotfix*/
+      - build:
+          context: org-global
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-snapshot)?(\-hotfix(\.[0-9]+))?/
@@ -415,8 +423,7 @@ workflows:
       - publish:
           context: org-global
           requires:
-#            - license-scan
-            - image-scan
+            - build
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-snapshot)?(\-hotfix(\.[0-9]+))?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,29 @@ jobs:
           path: /tmp/license-scanner/results
           prefix: licenses
 
+  build:
+    executor: default-ubuntu
+    steps:
+      - checkout
+      - run:
+          name: Build Docker $CIRCLE_TAG image
+          command: >
+            echo "Building Docker image: $CIRCLE_TAG"
+
+            docker build
+            --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
+            --build-arg=VERSION="$RELEASE_TAG"
+            --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
+            --build-arg=VCS_REF="$CIRCLE_SHA1"
+            -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+      - run:
+          name: Save docker image to workspace
+          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ./docker-image.tar
+
   build-local:
     executor: default-ubuntu
     steps:
@@ -255,29 +278,6 @@ jobs:
             # fi
       - store_artifacts:
           path: anchore-reports
-
-  build:
-    executor: default-ubuntu
-    steps:
-      - checkout
-      - run:
-          name: Build Docker $CIRCLE_TAG image
-          command: >
-            echo "Building Docker image: $CIRCLE_TAG"
-
-            docker build
-            --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
-            --build-arg=VERSION="$RELEASE_TAG"
-            --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
-            --build-arg=VCS_REF="$CIRCLE_SHA1"
-            -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
-      - run:
-          name: Save docker image to workspace
-          command: docker save -o /tmp/docker-image.tar $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - ./docker-image.tar
 
   publish:
     executor: default-ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,11 @@ defaults_license_scanner: &defaults_license_scanner
 # CircleCI Executors
 ##
 executors:
-  default-node:
+  docker-alpine-with-nodejs:
     working_directory: /home/circleci/project
     docker:
       - image: node:12.18.0-alpine
-  default-ubuntu:
+  machine-ubuntu-with-docker:
     machine:
       image: ubuntu-1604:201903-01
 
@@ -61,7 +61,7 @@ executors:
 ##
 jobs:
   setup:
-    executor: default-node
+    executor: docker-alpine-with-nodejs
     steps:
       - checkout
       - run:
@@ -82,7 +82,7 @@ jobs:
             - node_modules
 
   test-unit:
-    executor: default-node
+    executor: docker-alpine-with-nodejs
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
           path: ./test/results
 
   test-integration:
-    executor: default-node
+    executor: docker-alpine-with-nodejs
     steps:
       - checkout
       - run:
@@ -129,7 +129,7 @@ jobs:
           path: ./test/results
 
   vulnerability-check:
-    executor: default-node
+    executor: docker-alpine-with-nodejs
     steps:
       - checkout
       - run:
@@ -148,7 +148,7 @@ jobs:
           prefix: audit
 
   audit-licenses:
-    executor: default-node
+    executor: docker-alpine-with-nodejs
     steps:
       - checkout
       - run:
@@ -166,7 +166,7 @@ jobs:
           prefix: licenses
 
   build:
-    executor: default-ubuntu
+    executor: machine-ubuntu-with-docker
     steps:
       - checkout
       - run:
@@ -189,7 +189,7 @@ jobs:
             - ./docker-image.tar
 
   build-local:
-    executor: default-ubuntu
+    executor: machine-ubuntu-with-docker
     steps:
       - checkout
       - run:
@@ -212,7 +212,7 @@ jobs:
             - ./docker-image.tar
 
   license-scan:
-    executor: default-ubuntu
+    executor: machine-ubuntu-with-docker
     steps:
       - checkout
       - attach_workspace:
@@ -280,7 +280,7 @@ jobs:
           path: anchore-reports
 
   publish:
-    executor: default-ubuntu
+    executor: machine-ubuntu-with-docker
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,17 +391,16 @@ workflows:
                 - /feature*/
                 - /bugfix*/
                 - /hotfix*/
-      #      TODO: This job needs to have its issues diagnosed and fixed - currently does work against prebuilt images correctly
-      #      - license-scan:
-      #          context: org-global
-      #          requires:
-      #            - build-local
-      #          filters:
-      #            branches:
-      #              ignore:
-      #                - /feature*/
-      #                - /bugfix*/
-      #                - /hotfix*/
+            - license-scan:
+                context: org-global
+                requires:
+                  - build-local
+                filters:
+                  branches:
+                    ignore:
+                      - /feature*/
+                      - /bugfix*/
+                      - /hotfix*/
       - image-scan:
           context: org-global
           requires:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM node:12.18.0-alpine as builder
 
 RUN apk add --no-cache git
 
-WORKDIR /opt/reports
+WORKDIR /opt/reporting
 
-COPY package.json package-lock.json* /opt/reports/
-COPY src /opt/reports/src
+COPY package.json package-lock.json* /opt/reporting/
+COPY src /opt/reporting/src
 
 RUN npm ci --production
 
@@ -13,7 +13,7 @@ FROM node:12.18.0-alpine
 
 WORKDIR /opt/reports
 
-COPY --from=builder /opt/reports .
+COPY --from=builder /opt/reporting .
 
 EXPOSE 3000
-CMD ["npm", "run", "start"]
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci --production
 
 FROM node:12.18.0-alpine
 
-WORKDIR /opt/reports
+WORKDIR /opt/reporting
 
 COPY --from=builder /opt/reporting .
 

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -2,11 +2,11 @@
   "decisions": {
     "1500|npm-audit-resolver>audit-resolve-core>yargs-parser": {
       "decision": "postpone",
-      "madeAt": 1591374834568
+      "madeAt": 1591700595359
     },
     "1500|npm-audit-resolver>yargs-unparser>yargs>yargs-parser": {
       "decision": "postpone",
-      "madeAt": 1591374833489
+      "madeAt": 1591700594718
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mojaloop-reporting-service",
-  "version": "10.3.3",
+  "version": "10.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mojaloop-reporting-service",
-  "version": "10.3.3",
+  "version": "10.4.0",
   "description": "",
   "main": "src/server.js",
   "scripts": {


### PR DESCRIPTION
Diagnosed and fixed the issue with license-scan build step. It required changing the Dockerfile's directory structure to reflect the name of the deployed service, e.g. `reporting` rather than `reports`.

Altered pipeline to run `image-scan` and `license-scan` before merges rather than only on tags, so that issues would be spotted sooner in the development process. Added `build-local` step to facilitate this. Tagged releases no longer re-run the pipeline except for a fresh run of `build`, `publish`, and `deploy`.

Renamed `default-docker` to `docker-alpine-with-nodejs` to reflect its use. Renamed `default-machine` to `machine-ubuntu-with-docker` to better reflect its differentiation from the node image and its use.

Proposed pipeline for PR's:
<img width="1193" alt="Screen Shot 2020-06-09 at 14 10 19" src="https://user-images.githubusercontent.com/2804336/84151283-07555480-aa5b-11ea-8cbb-6544ad0d9b10.png">
