### PR TITLE
Allow build-local to run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,10 +381,6 @@ workflows:
                 - /hotfix*/
       - build-local:
           context: org-global
-          requires:
-            - test-unit
-            - vulnerability-check
-            - audit-licenses
           filters:
             branches:
               ignore:

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -2,7 +2,7 @@
   "decisions": {
     "1500|npm-audit-resolver>audit-resolve-core>yargs-parser": {
       "decision": "postpone",
-      "madeAt": 1591794012945
+      "madeAt": 1592315920550
     },
     "1500|npm-audit-resolver>yargs-unparser>yargs>yargs-parser": {
       "decision": "postpone",


### PR DESCRIPTION
This cuts build time almost in half.